### PR TITLE
[WIP] Recompute modifiers on date change, not just focus change

### DIFF
--- a/examples/TimTest.jsx
+++ b/examples/TimTest.jsx
@@ -1,0 +1,160 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import momentPropTypes from 'react-moment-proptypes';
+import moment from 'moment';
+import omit from 'lodash/omit';
+
+import DateRangePicker from '../src/components/DateRangePicker';
+
+import { DateRangePickerPhrases } from '../src/defaultPhrases';
+import DateRangePickerShape from '../src/shapes/DateRangePickerShape';
+import { START_DATE, END_DATE, HORIZONTAL_ORIENTATION, ANCHOR_LEFT } from '../constants';
+import isInclusivelyAfterDay from '../src/utils/isInclusivelyAfterDay';
+import isBeforeDay from '../src/utils/isBeforeDay';
+import isAfterDay from '../src/utils/isAfterDay';
+
+const propTypes = {
+  // example props for the demo
+  autoFocus: PropTypes.bool,
+  autoFocusEndDate: PropTypes.bool,
+  initialStartDate: momentPropTypes.momentObj,
+  initialEndDate: momentPropTypes.momentObj,
+
+  ...omit(DateRangePickerShape, [
+    'startDate',
+    'endDate',
+    'onDatesChange',
+    'focusedInput',
+    'onFocusChange',
+  ]),
+};
+
+const defaultProps = {
+  // example props for the demo
+  autoFocus: false,
+  autoFocusEndDate: false,
+  initialStartDate: null,
+  initialEndDate: null,
+
+  // input related props
+  startDateId: START_DATE,
+  startDatePlaceholderText: 'Start Date',
+  endDateId: END_DATE,
+  endDatePlaceholderText: 'End Date',
+  disabled: false,
+  required: false,
+  screenReaderInputMessage: '',
+  showClearDates: false,
+  showDefaultInputIcon: false,
+  customInputIcon: null,
+  customArrowIcon: null,
+  customCloseIcon: null,
+
+  // calendar presentation and interaction related props
+  renderMonth: null,
+  orientation: HORIZONTAL_ORIENTATION,
+  anchorDirection: ANCHOR_LEFT,
+  horizontalMargin: 0,
+  withPortal: false,
+  withFullScreenPortal: false,
+  initialVisibleMonth: null,
+  numberOfMonths: 2,
+  keepOpenOnDateSelect: false,
+  reopenPickerOnClearDates: false,
+  isRTL: false,
+
+  // navigation related props
+  navPrev: null,
+  navNext: null,
+  onPrevMonthClick() {},
+  onNextMonthClick() {},
+
+  // day presentation and interaction related props
+  renderDay: null,
+  minimumNights: 1,
+  enableOutsideDays: false,
+  isDayBlocked: () => false,
+  isOutsideRange: day => !isInclusivelyAfterDay(day, moment()),
+  isDayHighlighted: () => false,
+
+  // internationalization
+  displayFormat: () => moment.localeData().longDateFormat('L'),
+  monthFormat: 'MMMM YYYY',
+  phrases: DateRangePickerPhrases,
+};
+
+class TimTest extends React.Component {
+  constructor(props) {
+    super(props);
+
+    let focusedInput = null;
+    if (props.autoFocus) {
+      focusedInput = START_DATE;
+    } else if (props.autoFocusEndDate) {
+      focusedInput = END_DATE;
+    }
+
+    this.state = {
+      focusedInput,
+      startDate: props.initialStartDate,
+      endDate: props.initialEndDate,
+    };
+
+    this.onDatesChange = this.onDatesChange.bind(this);
+    this.onFocusChange = this.onFocusChange.bind(this);
+    this.isOutsideRange = this.isOutsideRange.bind(this);
+  }
+
+  onDatesChange({ startDate, endDate }) {
+    this.setState({ startDate, endDate });
+  }
+
+  onFocusChange(focusedInput) {
+    this.setState({ focusedInput });
+  }
+
+  isOutsideRange(day) {
+    const { focusedInput, startDate, endDate } = this.state;
+
+    if (focusedInput === START_DATE && endDate) {
+      return isAfterDay(day.clone().subtract(7, 'days'), endDate);
+    } else if (focusedInput === END_DATE && startDate) {
+      return isBeforeDay(day.clone().add(7, 'days'), startDate);
+    }
+
+    return false;
+  }
+
+  render() {
+    const { focusedInput, startDate, endDate } = this.state;
+
+    // autoFocus, autoFocusEndDate, initialStartDate and initialEndDate are helper props for the
+    // example wrapper but are not props on the SingleDatePicker itself and
+    // thus, have to be omitted.
+    const props = omit(this.props, [
+      'autoFocus',
+      'autoFocusEndDate',
+      'initialStartDate',
+      'initialEndDate',
+    ]);
+
+    return (
+      <div>
+        <DateRangePicker
+          {...props}
+          onDatesChange={this.onDatesChange}
+          onFocusChange={this.onFocusChange}
+          focusedInput={focusedInput}
+          startDate={startDate}
+          endDate={endDate}
+          isOutsideRange={this.isOutsideRange}
+        />
+      </div>
+    );
+  }
+}
+
+TimTest.propTypes = propTypes;
+TimTest.defaultProps = defaultProps;
+
+export default TimTest;

--- a/examples/TimTestSingle.jsx
+++ b/examples/TimTestSingle.jsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import momentPropTypes from 'react-moment-proptypes';
+import moment from 'moment';
+import omit from 'lodash/omit';
+
+import SingleDatePicker from '../src/components/SingleDatePicker';
+
+import { SingleDatePickerPhrases } from '../src/defaultPhrases';
+import SingleDatePickerShape from '../src/shapes/SingleDatePickerShape';
+import { HORIZONTAL_ORIENTATION, ANCHOR_LEFT } from '../constants';
+import isInclusivelyAfterDay from '../src/utils/isInclusivelyAfterDay';
+
+const propTypes = {
+  // example props for the demo
+  autoFocus: PropTypes.bool,
+  initialDate: momentPropTypes.momentObj,
+
+  ...omit(SingleDatePickerShape, [
+    'date',
+    'onDateChange',
+    'focused',
+    'onFocusChange',
+  ]),
+};
+
+const defaultProps = {
+  // example props for the demo
+  autoFocus: false,
+  initialDate: null,
+
+  // input related props
+  id: 'date',
+  placeholder: 'Date',
+  disabled: false,
+  required: false,
+  screenReaderInputMessage: '',
+  showClearDate: false,
+  showDefaultInputIcon: false,
+  customInputIcon: null,
+
+  // calendar presentation and interaction related props
+  renderMonth: null,
+  orientation: HORIZONTAL_ORIENTATION,
+  anchorDirection: ANCHOR_LEFT,
+  horizontalMargin: 0,
+  withPortal: false,
+  withFullScreenPortal: false,
+  initialVisibleMonth: null,
+  numberOfMonths: 2,
+  keepOpenOnDateSelect: false,
+  reopenPickerOnClearDate: false,
+  isRTL: false,
+
+  // navigation related props
+  navPrev: null,
+  navNext: null,
+  onPrevMonthClick() {},
+  onNextMonthClick() {},
+
+  // day presentation and interaction related props
+  renderDay: null,
+  enableOutsideDays: false,
+  isDayBlocked: () => false,
+  isOutsideRange: day => !isInclusivelyAfterDay(day, moment()),
+  isDayHighlighted: () => {},
+
+  // internationalization props
+  displayFormat: () => moment.localeData().longDateFormat('L'),
+  monthFormat: 'MMMM YYYY',
+  phrases: SingleDatePickerPhrases,
+};
+
+class SingleDatePickerWrapper extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      focused: props.autoFocus,
+      date: props.initialDate,
+    };
+
+    this.onDateChange = this.onDateChange.bind(this);
+    this.onFocusChange = this.onFocusChange.bind(this);
+    this.isOutsideRange = this.isOutsideRange.bind(this);
+  }
+
+  onDateChange(date) {
+    this.setState({ date });
+  }
+
+  onFocusChange({ focused }) {
+    this.setState({ focused });
+  }
+
+  isOutsideRange(day) {
+    const { date } = this.state;
+
+    return day && isInclusivelyAfterDay(day.clone().subtract(7, 'days'), date);
+  }
+
+  render() {
+    const { focused, date } = this.state;
+
+    // autoFocus and initialDate are helper props for the example wrapper but are not
+    // props on the SingleDatePicker itself and thus, have to be omitted.
+    const props = omit(this.props, [
+      'autoFocus',
+      'initialDate',
+    ]);
+
+    return (
+      <SingleDatePicker
+        {...props}
+        id="date_input"
+        date={date}
+        focused={focused}
+        onDateChange={this.onDateChange}
+        onFocusChange={this.onFocusChange}
+        isOutsideRange={this.isOutsideRange}
+      />
+    );
+  }
+}
+
+SingleDatePickerWrapper.propTypes = propTypes;
+SingleDatePickerWrapper.defaultProps = defaultProps;
+
+export default SingleDatePickerWrapper;

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -285,7 +285,7 @@ export default class DayPickerRangeController extends React.Component {
       }
     }
 
-    if (didFocusChange) {
+    if (didFocusChange || didStartDateChange || didEndDateChange) {
       values(visibleDays).forEach((days) => {
         Object.keys(days).forEach((day) => {
           const momentObj = moment(day);

--- a/src/components/DayPickerSingleDateController.jsx
+++ b/src/components/DayPickerSingleDateController.jsx
@@ -208,10 +208,22 @@ export default class DayPickerSingleDateController extends React.Component {
       modifiers = this.addModifier(modifiers, date, 'selected');
     }
 
-    if (didFocusChange) {
+    if (didFocusChange || didDateChange) {
       values(visibleDays).forEach((days) => {
         Object.keys(days).forEach((day) => {
           const momentObj = moment(day);
+          if (this.isBlocked(momentObj)) {
+            modifiers = this.addModifier(modifiers, momentObj, 'blocked');
+          } else {
+            modifiers = this.deleteModifier(modifiers, momentObj, 'blocked');
+          }
+
+          if (isOutsideRange(momentObj)) {
+            modifiers = this.addModifier(modifiers, momentObj, 'blocked-out-of-range');
+          } else {
+            modifiers = this.deleteModifier(modifiers, momentObj, 'blocked-out-of-range');
+          }
+
           if (isDayBlocked(momentObj)) {
             modifiers = this.addModifier(modifiers, momentObj, 'blocked-calendar');
           } else {

--- a/stories/DateRangePicker.js
+++ b/stories/DateRangePicker.js
@@ -4,6 +4,7 @@ import momentJalaali from 'moment-jalaali';
 import { storiesOf } from '@storybook/react';
 
 import DateRangePickerWrapper from '../examples/DateRangePickerWrapper';
+import TimTest from '../examples/TimTest';
 
 const TestInput = props => (
   <div style={{ marginTop: 16 }}>
@@ -50,6 +51,9 @@ class TestWrapper extends React.Component {
 }
 
 storiesOf('DateRangePicker (DRP)', module)
+  .addWithInfo('Test -- state-dependent isOutsideRange()', () => (
+    <TimTest />
+  ))
   .addWithInfo('default', () => (
     <DateRangePickerWrapper />
   ))

--- a/stories/SingleDatePicker.js
+++ b/stories/SingleDatePicker.js
@@ -4,6 +4,7 @@ import momentJalaali from 'moment-jalaali';
 import { storiesOf } from '@storybook/react';
 
 import SingleDatePickerWrapper from '../examples/SingleDatePickerWrapper';
+import TimTestSingle from '../examples/TimTestSingle';
 
 const TestInput = props => (
   <div style={{ marginTop: 16 }} >
@@ -22,6 +23,12 @@ const TestInput = props => (
 );
 
 storiesOf('SingleDatePicker (SDP)', module)
+  .addWithInfo('Test -- state-dependent isOutsideRange()', () => (
+    <TimTestSingle
+      keepOpenOnDateSelect
+      autoFocus
+    />
+  ))
   .addWithInfo('default', () => (
     <SingleDatePickerWrapper />
   ))


### PR DESCRIPTION
(Rebased and re-added changes in #550)

Addresses #570.

Currently, block / range related modifiers are only recomputed when the currently focused input changes. However, this causes some issues when more complex block / range functions are used, e.g. those that make selectable dates conditional on current state.

This commit gives one potential fix, which is to recompute modifiers not just on focus change, but also on start / end date change. This DOES result in a slight perf cost because modifiers are computed more frequently; however from my experience perf bottlenecks have mainly arisen on month changes (where 30 new days are added and recomputed) and on hover changes (fixed in v11.x), not on selection change.

The added story gives an example of a case where range modifier computation does not work as expected. The added wrapper component has the following validation: start dates must be no earlier than 1 week after selected end date, and end dates must be no later than 1 week after selected start date. Without the change in `DayPickerRangeController`, the following actions lead to a bug:

1. Pick a start date. Note the modifiers correctly recompute after the end date is focused.
2. Click on a date BEFORE the start date. `react-dates` behavior is to change the currently selected start date. However, note that the modifiers DO NOT recompute.

Additionally, there is a similar bug when `keepOpenOnDateSelect` is enabled, which is more noticeable with the `SingleDatePicker`. Because modifiers recompute when the focused input toggles between `null` and the input, modifiers are never recomputed until the calendar is closed and reopened. The story in `SingleDatePicker` showcases this -- when the change in `SingleDatePicker.jsx` is undone, the modifier never recomputes.

If this change seems ok I'll delete the changes to unrelated files, and add test cases. Thanks!